### PR TITLE
Feat cambiar uso de componente multi select ahora fast select

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -36,25 +36,36 @@ if (!function_exists('prepareFormRequestName')) {
         return $requestName;
     }
 }
- 
+
+if (!function_exists('isORMObj')) {
+    function isORMObj($obj)
+    {
+        return method_exists($obj, 'count');
+    }
+}
+
 if (!function_exists('prepareCheckboxValuesFromRows')) {
     function prepareCheckboxValuesFromRows($items, $config = [])
     {
+        $shouldLoopForValues = (isORMObj($items) && $items->count()) || (!isORMObj($items) && is_array($items));
         $values = [];
 
-        $valueRef       = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
-        $labelRef       = isset($config['labelRef']) ? $config['labelRef'] : 'name'; // default name
-        $secondLabelRef = isset($config['secondLabelRef']) ? $config['secondLabelRef'] : ''; // default empty
-
-        if ($items->count()) {
+        if ($shouldLoopForValues) {
+            $valueRef       = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
+            $labelRef       = isset($config['labelRef']) ? $config['labelRef'] : 'name'; // default name
+            $secondLabelRef = isset($config['secondLabelRef']) ? $config['secondLabelRef'] : ''; // default empty
+        
             foreach($items as $item) {
+                $labelRefValue = isset($item->{$labelRef}) ? $item->{$labelRef} : '';
+                $secondLabelRefValue = isset($item->{$secondLabelRef}) ? $item->{$secondLabelRef} : '';
+                
                 $values[] = [
-                    'label' => $item->{$labelRef}.' '.$item->{$secondLabelRef},
-                    'value' => $item->{$valueRef},
+                    'label' => trim($labelRefValue . ' ' . $item->{$secondLabelRefValue}),
+                    'value' => isset($item->{$valueRef}) ? $item->{$valueRef} : '',
                 ];
             }
         }
-        
+
         return $values;
     }
 }
@@ -62,13 +73,14 @@ if (!function_exists('prepareCheckboxValuesFromRows')) {
 if (!function_exists('prepareCheckboxDefaultValues')) {
     function prepareCheckboxDefaultValues($items, $config = [])
     {
+        $shouldLoopForValues = (isORMObj($items) && $items->count()) || (!isORMObj($items) && is_array($items));
         $defaultValues = [];
 
-        $valueRef = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
+        if ($shouldLoopForValues) {
+            $valueRef = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
 
-        if ($items->count()) {
             foreach($items as $item) {
-                $defaultValues[] = $item->{$valueRef};
+                $defaultValues[] = isset($item->{$valueRef}) ? $item->{$valueRef} : '';
             }
         }
         
@@ -79,15 +91,17 @@ if (!function_exists('prepareCheckboxDefaultValues')) {
 if (!function_exists('prepareSelectValuesFromRows')) {
     function prepareSelectValuesFromRows($items, $config = [])
     {
+        $shouldLoopForValues = (isORMObj($items) && $items->count()) || (!isORMObj($items) && is_array($items));
         $values = [];
 
-        $valueRef       = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
-        $labelRef       = isset($config['labelRef']) ? $config['labelRef'] : 'name'; // default name
-        if ($items->count()) {
+        if ($shouldLoopForValues) {
+            $valueRef       = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
+            $labelRef       = isset($config['labelRef']) ? $config['labelRef'] : 'name'; // default name
+
             foreach($items as $item) {
                 $values[] = [
-                    'label' => $item->{$labelRef},
-                    'value' => $item->{$valueRef},
+                    'label' => isset($item->{$labelRef}) ? $item->{$labelRef} : '',
+                    'value' => isset($item->{$valueRef}) ? $item->{$valueRef} : '',
                 ];
             }
         }
@@ -99,13 +113,14 @@ if (!function_exists('prepareSelectValuesFromRows')) {
 if (!function_exists('prepareSelectDefaultValues')) {
     function prepareSelectDefaultValues($items, $config = [])
     {
+        $shouldLoopForValues = (isORMObj($items) && $items->count()) || (!isORMObj($items) && is_array($items));
         $defaultValues = [];
 
-        $valueRef = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
+        if ($shouldLoopForValues) {
+            $valueRef = isset($config['valueRef']) ? $config['valueRef'] : 'id'; // default id
 
-        if ($items->count()) {
             foreach($items as $item) {
-                $defaultValues[] = $item->{$valueRef};
+                $defaultValues[] = isset($item->{$valueRef}) ? $item->{$valueRef} : '';
             }
         }
 

--- a/app/Repositories/PropertiesRepository.php
+++ b/app/Repositories/PropertiesRepository.php
@@ -101,9 +101,7 @@ class PropertiesRepository implements PropertiesRepositoryInterface
         $property->es->save();
 
         // amenities assignation
-        if ($request->amenities_ids && is_array($request->amenities_ids) && count($request->amenities_ids)) {
-            $property->amenities()->sync($request->amenities_ids);
-        }
+        $property->amenities()->sync($request->amenities_ids);
         
         return $property;
     }

--- a/resources/views/cleaning-services/partials/form-fields.blade.php
+++ b/resources/views/cleaning-services/partials/form-fields.blade.php
@@ -15,19 +15,6 @@
         ])
 
         <!-- cleaning_staff_ids -->
-        {{-- @include('components.form.checkbox-multiple', [
-            'group' => 'cleaning-staff',
-            'label' => __('Cleaning Staff'),
-            'name' => 'cleaning_staff_ids',
-            'values' => prepareCheckboxValuesFromRows($cleaning_staff, [
-                'labelRef' => 'full_name',
-            ]),
-            'default' => prepareCheckboxDefaultValues($row->cleaningStaff, [
-                'valueRef' => 'id',
-            ]),
-        ]) --}}
-
-         <!-- amenities -->
         @include('components.form.fast-select', [
             'group' => 'cleaning-staff',
             'label' => __('Cleaning Staff'),

--- a/resources/views/cleaning-services/partials/form-fields.blade.php
+++ b/resources/views/cleaning-services/partials/form-fields.blade.php
@@ -15,7 +15,7 @@
         ])
 
         <!-- cleaning_staff_ids -->
-        @include('components.form.checkbox-multiple', [
+        {{-- @include('components.form.checkbox-multiple', [
             'group' => 'cleaning-staff',
             'label' => __('Cleaning Staff'),
             'name' => 'cleaning_staff_ids',
@@ -25,6 +25,16 @@
             'default' => prepareCheckboxDefaultValues($row->cleaningStaff, [
                 'valueRef' => 'id',
             ]),
+        ]) --}}
+
+         <!-- amenities -->
+        @include('components.form.fast-select', [
+            'group' => 'cleaning-staff',
+            'label' => __('Cleaning Staff'),
+            'multiple' => true,
+            'name' => 'cleaning_staff_ids',
+            'options' => prepareSelectValuesFromRows($cleaning_staff, ['labelRef' => 'full_name']),
+            'default' => prepareSelectDefaultValues($row->cleaningStaff, ['valueRef' => 'id']),
         ])
 
         <!-- date -->

--- a/resources/views/components/form/fast-select.blade.php
+++ b/resources/views/components/form/fast-select.blade.php
@@ -10,6 +10,12 @@
     $disabled = isset($disabled) ? $disabled : false;
     $disableDefaultOption = isset($disableDefaultOption) ? (bool) $disableDefaultOption : false;
     $hidden = isset($hidden) ? (bool) $hidden : false;
+    $default = isset($default) ? $default : false;
+    
+    if($multiple && $default === false) {
+        $default = [];
+    }
+
 
     $options = isset($options) && count($options) ? $options : [];
 
@@ -18,6 +24,9 @@
 
     $requestName = prepareFormRequestName($name, $parentName, $lang);
     $inputName = prepareFormInputName($name, $parentName, $lang);
+    if($multiple) {
+        $inputName = $inputName . '[]';
+    }
 
     $multipleProp = ($multiple) ? 'multiple' : '';
     $disabledProp = ($disabled) ? 'disabled' : '';
@@ -37,7 +46,7 @@
     <div class="col-sm-10">
         <select
             {{ $multipleProp }}
-            name="{{ $inputName }}[]"
+            name="{{ $inputName }}"
             class="{{ $className }} form-control"
             id="{{ $id }}"
             data-placeholder="{{ $placeholder }}"
@@ -49,7 +58,10 @@
 
             @foreach($options as $option)
                 @php
-                    $selected = (in_array($option['value'], old($requestName, $default)))?'selected':'';
+                    $defaultValue = old($requestName, $default);
+                    $defaultValue = is_array($defaultValue) ? $defaultValue : [];
+
+                    $selected = (in_array($option['value'], $defaultValue)) ? 'selected' : '';
                 @endphp
 
                 <option value="{{ $option['value'] }}" {{ $selected }}>

--- a/resources/views/contacts/index.blade.php
+++ b/resources/views/contacts/index.blade.php
@@ -3,7 +3,7 @@
 @section('heading-content')
 
     @include('components.heading', [
-        'label' => __('Contact'),
+        'label' => __('Contacts'),
         'actions' => [
             [
                 'label' => __('New'),

--- a/resources/views/contractors-services/partials/form-fields.blade.php
+++ b/resources/views/contractors-services/partials/form-fields.blade.php
@@ -10,15 +10,14 @@
         @endif 
 
         <!-- contractor_id -->
-        @include('components.form.select', [
+        @include('components.form.fast-select', [
             'group' => 'contractor-service',
             'label' => __('Contractor'),
+            'multiple' => false,
             'name' => 'contractor_id',
             'required' => true,
-            'value' => $row->contractor_id,
-            'options' => $contractors,
-            'optionValueRef' => 'id',
-            'optionLabelRef' => 'company',
+            'options' => prepareSelectValuesFromRows($contractors, ['valueRef' => 'id', 'labelRef' => 'company']),
+            'default' => prepareSelectDefaultValues([$row->contractor], ['valueRef' => 'id']),
         ])
 
         <!-- base_price -->

--- a/resources/views/property-contacts/partials/form-fields.blade.php
+++ b/resources/views/property-contacts/partials/form-fields.blade.php
@@ -11,18 +11,14 @@
             'value' => $row->id
         ])
 
-        <!-- contact_id -->
-        @include('components.form.checkbox-multiple', [
+        <!-- contacts_id -->
+        @include('components.form.fast-select', [
             'group' => 'property-contact',
             'label' => __('Contacts'),
+            'multiple' => true,
             'name' => 'contacts_ids',
-            'values' => prepareCheckboxValuesFromRows($contacts, [
-                'valueRef' => 'id',
-                'labelRef' => 'full_name'
-            ]),
-            'default' => prepareCheckboxDefaultValues($row->contacts, [
-                'valueRef' => 'id',
-            ]),
+            'options' => prepareSelectValuesFromRows($contacts, ['labelRef' => 'full_name']),
+            'default' => prepareSelectDefaultValues($row->contacts, ['valueRef' => 'id']),
         ])
 
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,23 +34,6 @@ Route::group(['middleware' => ['web']], function () {
             Route::get('', 'ProfileController@edit')->name('profile');
             Route::post('update', 'ProfileController@update')->name('profile.update');
         });
-
-
-        // bookings
-        Route::group(['prefix' => 'booking'], function () {
-
-            // agents
-            Route::group(['prefix' => 'agents', 'middleware' => 'role-permission:booking,agents'], function () {
-                Route::get('', 'AgentsController@index')->name('agents');
-                Route::get('create', 'AgentsController@create')->name('agents.create');
-                Route::post('store', 'AgentsController@store')->name('agents.store');
-                Route::get('show/{agent}', 'AgentsController@show')->name('agents.show');
-                Route::get('edit/{agent}', 'AgentsController@edit')->name('agents.edit');
-                Route::post('update/{id}', 'AgentsController@update')->name('agents.update');
-                Route::get('destroy/{id}', 'AgentsController@destroy')->name('agents.destroy');
-            });
-        });
-
   
         // contractors
         Route::group(['prefix' => 'contractors', 'middleware' => 'role-permission:contractors,index'], function () {
@@ -95,6 +78,17 @@ Route::group(['middleware' => ['web']], function () {
             // bookings by owner
             Route::group(['middleware' => 'role-permission:bookings,owner'], function () {
                 Route::get('property/{owner}', 'BookingController@ownerBookings')->name('bookings.by-owner');
+            });
+
+            // agents
+            Route::group(['prefix' => 'agents', 'middleware' => 'role-permission:bookings,agents'], function () {
+                Route::get('', 'AgentsController@index')->name('agents');
+                Route::get('create', 'AgentsController@create')->name('agents.create');
+                Route::post('store', 'AgentsController@store')->name('agents.store');
+                Route::get('show/{agent}', 'AgentsController@show')->name('agents.show');
+                Route::get('edit/{agent}', 'AgentsController@edit')->name('agents.edit');
+                Route::post('update/{id}', 'AgentsController@update')->name('agents.update');
+                Route::get('destroy/{id}', 'AgentsController@destroy')->name('agents.destroy');
             });
         });
 


### PR DESCRIPTION
- [x] se implementó el componente de fast-select en lugares donde hay opción multiple de select
- [x] se modificó el fast-select para poder usarlo en selects con opciones no múltiple solo en algunos lugares
- [x] se usó en los selects que tienen o van a tener muchas opciones, la ventaja del fast-select viene siendo su campo de búsqueda

Nota: el fast-select para usar en selects de una opción a seleccionar, no funciona aún cuando se usan opciones para el select que pertenecen a tablas de traducciones; ... en cambio, si funciona para las tablas con o sin traducciones cuando se usa para opciones múltiples, esto es por la implementación actual del componente. 

Más adelante y cuando sea prioridad o necesario voy a agregar esa funcionalidad extra.


![Screen Shot 2020-06-03 at 12 46 02](https://user-images.githubusercontent.com/60666952/83670149-58b39e80-a598-11ea-9b02-2fec348bcf2b.png)


![Screen Shot 2020-06-03 at 12 46 58](https://user-images.githubusercontent.com/60666952/83670157-5c472580-a598-11ea-9b31-a4474daa3aa3.png)
